### PR TITLE
GraphQL for Circles -  #14

### DIFF
--- a/hasura/migrations/1586104975028_alter_table_public_Circles_add_column_Subject/down.yaml
+++ b/hasura/migrations/1586104975028_alter_table_public_Circles_add_column_Subject/down.yaml
@@ -1,0 +1,3 @@
+- args:
+    sql: ALTER TABLE "public"."Circles" DROP COLUMN "Subject";
+  type: run_sql

--- a/hasura/migrations/1586104975028_alter_table_public_Circles_add_column_Subject/up.yaml
+++ b/hasura/migrations/1586104975028_alter_table_public_Circles_add_column_Subject/up.yaml
@@ -1,0 +1,3 @@
+- args:
+    sql: ALTER TABLE "public"."Circles" ADD COLUMN "Subject" text NULL;
+  type: run_sql

--- a/hasura/migrations/1586105230373_alter_table_public_Circles_add_column_Private/down.yaml
+++ b/hasura/migrations/1586105230373_alter_table_public_Circles_add_column_Private/down.yaml
@@ -1,0 +1,3 @@
+- args:
+    sql: ALTER TABLE "public"."Circles" DROP COLUMN "Private";
+  type: run_sql

--- a/hasura/migrations/1586105230373_alter_table_public_Circles_add_column_Private/up.yaml
+++ b/hasura/migrations/1586105230373_alter_table_public_Circles_add_column_Private/up.yaml
@@ -1,0 +1,4 @@
+- args:
+    sql: ALTER TABLE "public"."Circles" ADD COLUMN "Private" boolean NOT NULL DEFAULT
+      TRUE;
+  type: run_sql

--- a/hasura/migrations/1586105606244_alter_table_public_Circles_add_column_Name/down.yaml
+++ b/hasura/migrations/1586105606244_alter_table_public_Circles_add_column_Name/down.yaml
@@ -1,0 +1,3 @@
+- args:
+    sql: ALTER TABLE "public"."Circles" DROP COLUMN "Name";
+  type: run_sql

--- a/hasura/migrations/1586105606244_alter_table_public_Circles_add_column_Name/up.yaml
+++ b/hasura/migrations/1586105606244_alter_table_public_Circles_add_column_Name/up.yaml
@@ -1,0 +1,4 @@
+- args:
+    sql: ALTER TABLE "public"."Circles" ADD COLUMN "Name" text NOT NULL DEFAULT 'My
+      Circle';
+  type: run_sql

--- a/package-lock.json
+++ b/package-lock.json
@@ -5671,6 +5671,11 @@
       "resolved": "https://registry.npmjs.org/lodash.curry/-/lodash.curry-4.1.1.tgz",
       "integrity": "sha1-JI42By7ekGUB11lmIAqG2riyMXA="
     },
+    "lodash.debounce": {
+      "version": "4.0.8",
+      "resolved": "https://registry.npmjs.org/lodash.debounce/-/lodash.debounce-4.0.8.tgz",
+      "integrity": "sha1-gteb/zCmfEAF/9XiUVMArZyk168="
+    },
     "lodash.template": {
       "version": "4.5.0",
       "resolved": "https://registry.npmjs.org/lodash.template/-/lodash.template-4.5.0.tgz",
@@ -7560,6 +7565,15 @@
         "loose-envify": "^1.1.0",
         "object-assign": "^4.1.1",
         "prop-types": "^15.6.2"
+      }
+    },
+    "react-debounce-input": {
+      "version": "3.2.2",
+      "resolved": "https://registry.npmjs.org/react-debounce-input/-/react-debounce-input-3.2.2.tgz",
+      "integrity": "sha512-RIBu68Cq/gImKz/2h1cE042REDqyqj3D+7SJ3lnnIpJX0ht9D9PfH7KAnL+SgDz6hvKa9pZS2CnAxlkrLmnQlg==",
+      "requires": {
+        "lodash.debounce": "^4",
+        "prop-types": "^15.7.2"
       }
     },
     "react-dom": {

--- a/package.json
+++ b/package.json
@@ -31,6 +31,7 @@
     "now": "^16.7.3",
     "prop-types": "^15.7.2",
     "react": "16.12.0",
+    "react-debounce-input": "^3.2.2",
     "react-dom": "16.12.0",
     "react-is": "^16.12.0",
     "react-popper": "^1.3.7",

--- a/pages/app/circles.js
+++ b/pages/app/circles.js
@@ -82,18 +82,17 @@ const Circles = () => {
   })
 
   useEffect(() => {
-    if(!getPublicCirclesResult.fetching) {
+    if(!getPublicCirclesResult.fetching && getPublicCirclesResult.data) {
       setPublicCircles(getPublicCirclesResult.data.Circles)
     }
   }, [getPublicCirclesResult])
 
   useEffect(() => {
-    if(!searchUserByEmailResult.fetching) {
+    if(!searchUserByEmailResult.fetching && searchUserByEmailResult.data) {
       setCircles( searchUserByEmailResult.data.CircleMembers.map(item => item.Circle))
     }
   }, [searchUserByEmailResult])
 
-  console.log(circles)
   return (
     <div>
       <AppHeader header={[{name: 'Dashboard', dest: '/app'}, {name: 'Circles', dest: '/app/circles'}]}/>
@@ -109,7 +108,7 @@ const Circles = () => {
 
       <Container pt={3}>
         <Divider />
-      </Container>   
+      </Container>
 
       <Container pt={3}>
         <Text variant='heading' mb={3}>
@@ -122,7 +121,7 @@ const Circles = () => {
 
       <Container pt={3}>
         <Divider />
-      </Container>   
+      </Container>
 
       <Container pt={3}>
         <Text variant='heading' mb={3}>

--- a/pages/app/circles/create.js
+++ b/pages/app/circles/create.js
@@ -110,7 +110,7 @@ const CreateCircle = () => {
       if(member) {
         // Add to the list of members
         setMemberList([
-          ...memberList, 
+          ...memberList,
           {
             MemberUserId: searchUserByEmailResult.data.Users[0].Id,
             email: searchUserByEmailResult.data.Users[0].email
@@ -133,21 +133,24 @@ const CreateCircle = () => {
       subject: subject,
       name: circleName
     })
-    
+    console.log(creationResult)
     // Add the members in one go
     const membersResult = await executeCreateCircleMembers(
       {
-        objects: 
+        objects:
         memberList.map(
             user => {
               return {
-                CircleId: creationResult.data.insert_Circles.returning[0].Id, 
+                CircleId: creationResult.data.insert_Circles.returning[0].Id,
                 MemberUserId: user.MemberUserId
               }
             }
           )
       }
-    )    
+    )
+    if(!membersResult.error && !creationResult.error) {
+      window.alert("Your circle has been created!")
+    }
   }
 
   return (
@@ -206,7 +209,7 @@ const CreateCircle = () => {
           <div>
             <label style={{fontWeight: 'bold'}} mb='1'>
               Invite Members<br />
-           
+
               <form onSubmit={handleAddMember}>
                 <DebounceInput
                   name="members"
@@ -222,16 +225,16 @@ const CreateCircle = () => {
                   Invite
                 </AddMemberButton>
 
-              </form>      
+              </form>
               <ul id="list">
                 {memberList.map(item => {
                   return <li key={item.MemberUserId}>{item.email}</li>;
                 })}
-              </ul>   
+              </ul>
             </label>
           </div>
         </Container>
-          
+
         <Container pt={3}>
           <div>
             <CreateButton onClick={handleCreateCircle}>
@@ -244,6 +247,6 @@ const CreateCircle = () => {
     </div>
   )
 }
- 
+
 
 export default withLoginRequired(withAuth(CreateCircle))

--- a/pages/app/circles/create.js
+++ b/pages/app/circles/create.js
@@ -96,6 +96,11 @@ const CreateCircle = () => {
   useEffect(() => {
     if(!loggedInUserEmailResult.fetching) {
       setUserId(loggedInUserEmailResult.data.Users[0].Id)
+      // Add the admin as a member
+      setMemberList([{
+        MemberUserId:loggedInUserEmailResult.data.Users[0].Id,
+        email: loggedInUserEmailResult.data.Users[0].email
+      }])
     }
   }, [loggedInUserEmailResult])
 
@@ -122,29 +127,27 @@ const CreateCircle = () => {
 
   const handleCreateCircle = async () => {
     // We need to create the circle first and get the Circle Id back out
-    let creationResult = await executeCreateCircle({
+    const creationResult = await executeCreateCircle({
       userId: userId,
       private: privacy === 'private' ? true : false,
       subject: subject,
       name: circleName
     })
-    // Are there any members to add?
-    if(memberList.length > 0) {
-      // Add the members in one go
-      let membersResult = await executeCreateCircleMembers(
-        {
-          objects: 
-            memberList.map(
-              user => {
-                return {
-                  CircleId: creationResult.data.insert_Circles.returning[0].Id, 
-                  MemberUserId: user.MemberUserId
-                }
+    
+    // Add the members in one go
+    const membersResult = await executeCreateCircleMembers(
+      {
+        objects: 
+        memberList.map(
+            user => {
+              return {
+                CircleId: creationResult.data.insert_Circles.returning[0].Id, 
+                MemberUserId: user.MemberUserId
               }
-            )
-        }
-      )
-    }
+            }
+          )
+      }
+    )    
   }
 
   return (

--- a/pages/app/circles/view/[id].js
+++ b/pages/app/circles/view/[id].js
@@ -1,10 +1,16 @@
-import React, { useState } from 'react'
+import React, { useState, useEffect } from 'react'
 import { Flex, Box, Text, Button } from 'rebass'
 import { FontAwesomeIcon } from '@fortawesome/react-fontawesome'
+import { useRouter } from 'next/router'
 import { faUserPlus, faEdit, faWindowClose } from '@fortawesome/free-solid-svg-icons'
 import Link from 'next/link'
 import styled from '@emotion/styled'
 import { withAuth, withLoginRequired } from 'use-auth0-hooks'
+
+import { useQuery, useMutation } from 'urql'
+import { getCircleMembersById } from '../../../queries.js'
+import {DebounceInput} from 'react-debounce-input';
+
 
 import AppHeader from '../../../../components/app_header'
 import Divider from '../../../../components/divider'
@@ -146,7 +152,7 @@ const InviteMembersModal = ({ handleClose, show }) => {
 
   const [member, setMember] = useState('');
   const [memberList, setMemberList] = useState(inviteMembers);
-  
+
   const handleAddMember = (event) => {
     if(member) {
       setMemberList([...memberList, member]);
@@ -269,10 +275,35 @@ const EditCircleModal = ({ handleClose, show }) => {
   
 };
 
+const MemberCard = (props) => {
+  return (
+    <MembersBox width={0.15}>
+      <Text>{props.email}</Text>
+      {/* <img src='https://cf.mastohost.com/v1/AUTH_91eb37814936490c95da7b85993cc2ff/blackrockcity/accounts/avatars/000/000/001/original/cd46c94e39268f0b.jpg' width={50} height={50} /> */}
+    </MembersBox>
+  )
+}
+
 const Circle = () => {
   const [display, setDisplay] = useState(false);
+  const router = useRouter();
   const hide = () => setDisplay(false);
   const show = () => setDisplay(true);
+  const [currentMembers, setCurrentMembers] = useState([])
+
+  // Query for an members
+  const [membersQueryResult] = useQuery({
+    query: getCircleMembersById,
+    variables: {Id: router.query.id }
+  })
+
+  useEffect(() => {
+    if(!membersQueryResult.fetching) {
+      setCurrentMembers(membersQueryResult.data.CircleMembers)
+    }
+  }, [membersQueryResult])
+  
+  console.log(currentMembers)
 
   const handleToggle = () => {
     if(!display) {
@@ -340,10 +371,9 @@ const Circle = () => {
         </Text>
         
         <Container pt={3}>
-        <MembersBox width={0.15}>
-            <Text>Michael</Text>
-            <img src='https://cf.mastohost.com/v1/AUTH_91eb37814936490c95da7b85993cc2ff/blackrockcity/accounts/avatars/000/000/001/original/cd46c94e39268f0b.jpg' width={50} height={50} />
-        </MembersBox>
+        {
+          currentMembers.map(member => <MemberCard key={member.MemberUser.Id} email={member.MemberUser.email} />)
+        }
         </Container>   
 
   

--- a/pages/app/circles/view/[id].js
+++ b/pages/app/circles/view/[id].js
@@ -166,7 +166,7 @@ const InviteMembersModal = ({ handleClose, show, currentMembers, setCurrentMembe
       if(member) {
         // Add to the list of members
         setMemberList([
-          ...memberList, 
+          ...memberList,
           {
             Id: searchUserByEmailResult.data.Users[0].Id,
             email: searchUserByEmailResult.data.Users[0].email
@@ -187,11 +187,11 @@ const InviteMembersModal = ({ handleClose, show, currentMembers, setCurrentMembe
       // Add the members in one go
       const membersResult = await executeCreateCircleMembers(
         {
-          objects: 
+          objects:
             memberList.map(
               user => {
                 return {
-                  CircleId: router.query.id, 
+                  CircleId: router.query.id,
                   MemberUserId: user.Id
                 }
               }
@@ -215,7 +215,7 @@ const InviteMembersModal = ({ handleClose, show, currentMembers, setCurrentMembe
   if(!show) {
     return null;
   }
-  else { 
+  else {
     return (
       <Modal>
           <ModalBox>
@@ -237,8 +237,8 @@ const InviteMembersModal = ({ handleClose, show, currentMembers, setCurrentMembe
                   <FontAwesomeIcon icon={faUserPlus} />
                   Invite
                 </AddMemberButton>
-  
-              </form>      
+
+              </form>
               <ul id="list">
                 {memberList.map(item => {
                   return <li key={item.Id}>{item.email}</li>;
@@ -250,7 +250,7 @@ const InviteMembersModal = ({ handleClose, show, currentMembers, setCurrentMembe
       </Modal>
     )
   }
-  
+
 };
 
 const EditCircleModal = ({ handleClose, show, setNewCircleName }) => {
@@ -271,8 +271,9 @@ const EditCircleModal = ({ handleClose, show, setNewCircleName }) => {
         Id: router.query.id,
         Name: circleName,
         Subject: subject,
-        Privacy: privacy
+        Privacy: privacy === "private" ? true : false
       })
+      console.log(updateResult)
       if(!updateResult.error) {
         setNewCircleName(circleName)
         handleClose()
@@ -282,7 +283,7 @@ const EditCircleModal = ({ handleClose, show, setNewCircleName }) => {
   if(!show) {
     return null;
   }
-  else { 
+  else {
     return (
       <Modal>
           <ModalBox>
@@ -343,7 +344,7 @@ const EditCircleModal = ({ handleClose, show, setNewCircleName }) => {
       </Modal>
     )
   }
-  
+
 };
 
 const MemberCard = (props) => {
@@ -378,7 +379,7 @@ const Circle = () => {
       setCircleName(membersQueryResult.data.Circles[0].Name)
     }
   }, [membersQueryResult])
-  
+
 
   const handleToggle = () => {
     if(!display) {
@@ -405,7 +406,7 @@ const Circle = () => {
     event.preventDefault();
 
   };
-  
+
   return (
     <div>
         <AppHeader header={[{name: 'Dashboard', dest: '/app'}, {name: 'Circles', dest: '/app/circles'}, {name: circleName, dest: '/app/circles'}]}/>
@@ -438,32 +439,32 @@ const Circle = () => {
 
         <Container pt={3}>
             <Divider />
-        </Container>   
+        </Container>
 
         <Container pt={3}>
         <Text variant='heading' mb={3}>
             Members
         </Text>
-        
+
         <Container pt={3}>
         {
           currentMembers.map(member => <MemberCard key={member.Id} email={member.email} />)
         }
-        </Container>   
+        </Container>
 
-  
+
         </Container>
         {
-        display && 
+        display &&
         <InviteMembersModal show={display} currentMembers={currentMembers} setCurrentMembers={setCurrentMembers} handleClose={e => hide()} />
         }
         {
-        displayEdit && 
+        displayEdit &&
         <EditCircleModal show={displayEdit} setNewCircleName={setCircleName} handleClose={e => hideEdit()} />
         }
 
     </div>
-    
+
   )
 }
 

--- a/pages/queries.js
+++ b/pages/queries.js
@@ -186,8 +186,8 @@ mutation addFeedbackToSegmentBySegmentIdAndVersionAndUserId($segmentId: Int!, $c
 // Segments
 //
 export const addSegment = gql`
-mutation AddSegment($segmentName: String!, $id: Int!, $content: String!, $subjectCode: Int) {
-  insert_Segment(objects: {name: $segmentName, history: {data: {content: $content}}, userId: $id, Subject: $subjectCode}) {
+mutation AddSegment($segmentName: String!, $id: Int!, $content: String!) {
+  insert_Segment(objects: {name: $segmentName, history: {data: {content: $content}}, userId: $id}) {
     returning {
       name
       status
@@ -196,9 +196,6 @@ mutation AddSegment($segmentName: String!, $id: Int!, $content: String!, $subjec
       history {
         content
         version
-      }
-      SubjectCode {
-        Subject
       }
     }
   }

--- a/pages/queries.js
+++ b/pages/queries.js
@@ -122,7 +122,11 @@ query getCircleMembersById($Id: Int!) {
       Id
     }
   }
+  Circles(where: {Id: {_eq: $Id}}) {
+    Name
+  }
 }
+
 `
 export const getCircleMembershipForUserByEmail = gql`
 query getCircleMembershipForUserByEmail($email: String!) {
@@ -154,6 +158,13 @@ query getPublicCircles {
     CircleMembers {
       MemberUserId
     }
+  }
+}
+`
+export const updateCircleNameSubjectPrivacyById = gql`
+mutation updateCircleNameSubjectPrivacyById($Id: Int!, $Name: String!, $Subject: String!, $Privacy: Boolean!) {
+  update_Circles(where: {Id: {_eq: $Id}}, _set: {Name: $Name, Subject: $Subject, Private: $Privacy}) {
+    affected_rows
   }
 }
 `

--- a/pages/queries.js
+++ b/pages/queries.js
@@ -97,14 +97,23 @@ export const getUserPapers = gql`
 //
 // Circles
 //
-export const createCircleAdmin = gql`
-mutation CreateCircleAdmin($email: String!) {
-  insert_Circles(objects: {Admin: {data: {email: $email}}}) {
+export const createCircle = gql`
+mutation createCircle($userId: Int!, $private: Boolean!, $subject: String!, $name: String!) {
+  insert_Circles(objects: {AdminUserId: $userId, Private: $private, Subject: $subject, Name: $name}) {
     returning {
       Id
     }
   }
 }
+`
+
+export const createCircleMembers = gql`
+mutation createCircleMembers($objects: [CircleMembers_insert_input!]!) {
+  insert_CircleMembers(objects: $objects) {
+    affected_rows
+  }
+}
+
 `
 export const getCircleMembershipForUser = gql`
 query getCircleMembershipForUserQuery($email: String!) {

--- a/pages/queries.js
+++ b/pages/queries.js
@@ -113,7 +113,16 @@ mutation createCircleMembers($objects: [CircleMembers_insert_input!]!) {
     affected_rows
   }
 }
-
+`
+export const getCircleMembersById = gql`
+query getCircleMembersById($Id: Int!) {
+  CircleMembers(where: {CircleId: {_eq: $Id}}) {
+    MemberUser {
+      email
+      Id
+    }
+  }
+}
 `
 export const getCircleMembershipForUserByEmail = gql`
 query getCircleMembershipForUserByEmail($email: String!) {

--- a/pages/queries.js
+++ b/pages/queries.js
@@ -115,19 +115,35 @@ mutation createCircleMembers($objects: [CircleMembers_insert_input!]!) {
 }
 
 `
-export const getCircleMembershipForUser = gql`
-query getCircleMembershipForUserQuery($email: String!) {
-  CircleMembers(where: {MemberUser: {email: {_eq: $email}}}) {
+export const getCircleMembershipForUserByEmail = gql`
+query getCircleMembershipForUserByEmail($email: String!) {
+  CircleMembers(where: {_or: [{MemberUser: {email: {_eq: $email}}}, {Circle: {Admin: {email: {_eq: $email}}}}]}, distinct_on: CircleId) {
     Circle {
       Id
       Admin {
         email
       }
+      Name
+      Subject
       CircleMembers {
-        MemberUser {
-          email
-        }
+        MemberUserId
       }
+    }
+  }
+}
+`
+
+export const getPublicCircles = gql`
+query getPublicCircles {
+  Circles(where: {Private: {_eq: false}}) {
+    Subject
+    Name
+    Id
+    Admin {
+      email
+    }
+    CircleMembers {
+      MemberUserId
     }
   }
 }


### PR DESCRIPTION
This PR adds GraphQL for:
- Creating new circles with a name, subject, and inviting existing members via email
- Editing a circle's name, subject, and privacy
- Inviting more members into an existing circles

What is not complete:
- Viewing the papers shared in a circle
- Showing avatars/profile images for each user
- Users are identified using email currently, not names

![create](https://user-images.githubusercontent.com/26660036/78961002-ae8e2d80-7aa4-11ea-8463-a0c0e98c696c.gif)

![editingCircle](https://user-images.githubusercontent.com/26660036/78961006-b51ca500-7aa4-11ea-9c41-42926e4e51c6.gif)
![invitingOthers](https://user-images.githubusercontent.com/26660036/78961011-b8b02c00-7aa4-11ea-804a-7e8b5f2ff16a.gif)



resolves #14